### PR TITLE
Use $.getJSON for more reliable JSON parsing

### DIFF
--- a/map.html
+++ b/map.html
@@ -32,11 +32,9 @@
         maxZoom: 18
     }).addTo(map);
 
-    $.ajax({
-      url: 'output.json',
-      success: function(payload) {
-        var data = JSON.parse(payload);
-
+    $.getJSON(
+      'output.json',
+      function(data) {
         $.each(data, function (n, item) {
           if (item.lat && item.long) {
             var marker = L.marker([item.lat, item.long]).addTo(map);
@@ -44,14 +42,11 @@
             marker.bindPopup(item.description);
           }
         });
-      }
-    });
+      });
 
-    $.ajax({
-      url: 'areas.json',
-      success: function(payload) {
-        var data = JSON.parse(payload);
-
+    $.getJSON(
+      'areas.json',
+      function(data) {
         $.each(data, function (n, item) {
           var polygon = L.polygon(item.nodes, {color: 'orange'}).addTo(map);
 
@@ -60,8 +55,7 @@
           }
 
         });
-      }
-    });    
+      });
 
     </script>  
     <div class="copyright">  


### PR DESCRIPTION
Hi, this looks really nice! I was getting errors loading the JSON file in Firefox though, which was because `$.ajax` was parsing the json file before calling the success callback, and `JSON.parse(<array>)` apparently doesn't work.

Also, one can use [GitHub Pages](http://pages.github.com/) to host a static version of the webpage. All you need to do is create a branch called `gh-pages` with the content desired, and then you can access it [like so](http://huonw.github.io/burning-down/map.html). (I just created the gh-pages branch directly on top of my `getJSON` branch for that link.)
